### PR TITLE
chore: Add styles to PdfOptions interface and update mdastToPdf function

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -360,17 +360,17 @@ function buildTableCell(
 
 function buildHtml({ type, value }: mdast.HTML, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx), style: type };
+  return <ContentText>{ text: buildText(value, ctx)};
 }
 
 function buildCode({ type, value, lang, meta }: mdast.Code, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx), style: type };
+  return <ContentText>{ text: buildText(value, ctx)};
 }
 
 function buildMath({ type, value }: mdast.Math, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx), style: type };
+  return <ContentText>{ text: buildText(value, ctx)};
 }
 
 function buildInlineMath({ type, value }: mdast.InlineMath, ctx: Context) {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -70,6 +70,15 @@ export interface PdfOptions
   info?: TDocumentInformation;
 }
 
+function deepMerge(target: any, source: any): any {
+  for (const key in source) {
+    if (source[key] instanceof Object && key in target) {
+      Object.assign(source[key], deepMerge(target[key], source[key]));
+    }
+  }
+  return { ...target, ...source };
+}
+
 export function mdastToPdf(
   node: mdast.Root,
   {
@@ -88,6 +97,27 @@ export function mdastToPdf(
   images: ImageDataMap,
   build: (def: TDocumentDefinitions) => Promise<any>
 ): Promise<any> {
+  const defaultStyles = {
+    [HEADING_1]: {
+      fontSize: 24,
+    },
+    [HEADING_2]: {
+      fontSize: 22,
+    },
+    [HEADING_3]: {
+      fontSize: 20,
+    },
+    [HEADING_4]: {
+      fontSize: 18,
+    },
+    [HEADING_5]: {
+      fontSize: 16,
+    },
+    [HEADING_6]: {
+      fontSize: 14,
+    },
+  };
+  const mergedStyles = deepMerge(defaultStyles, styles);
   const content = convertNodes(node.children, { deco: {}, images });
   const doc = build({
     info,
@@ -101,7 +131,7 @@ export function mdastToPdf(
     watermark,
     content,
     images,
-    styles,
+    styles: mergedStyles,
     defaultStyle: {
       font: isBrowser() ? "Roboto" : "Helvetica",
     },

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -55,6 +55,7 @@ export interface PdfOptions
     | "ownerPassword"
     | "permissions"
     | "version"
+    | "styles"
     | "watermark"
   > {
   /**
@@ -79,6 +80,7 @@ export function mdastToPdf(
     pageSize,
     userPassword,
     ownerPassword,
+    styles,
     permissions,
     version,
     watermark,
@@ -99,30 +101,12 @@ export function mdastToPdf(
     watermark,
     content,
     images,
+    styles,
     defaultStyle: {
       font: isBrowser() ? "Roboto" : "Helvetica",
     },
-    styles: {
-      [HEADING_1]: {
-        fontSize: 24,
-      },
-      [HEADING_2]: {
-        fontSize: 22,
-      },
-      [HEADING_3]: {
-        fontSize: 20,
-      },
-      [HEADING_4]: {
-        fontSize: 18,
-      },
-      [HEADING_5]: {
-        fontSize: 16,
-      },
-      [HEADING_6]: {
-        fontSize: 14,
-      },
-    },
-  });
+  }
+  );
   return doc;
 }
 
@@ -230,7 +214,7 @@ function convertNodes(nodes: mdast.Content[], ctx: Context) {
 }
 
 function buildParagraph({ type, children }: mdast.Paragraph, ctx: Context) {
-  return <ContentText>{ text: convertNodes(children, ctx) };
+  return <ContentText>{ text: convertNodes(children, ctx), style: type, };
 }
 
 function buildHeading({ type, children, depth }: mdast.Heading, ctx: Context) {
@@ -278,7 +262,7 @@ function buildThematicBreak({ type }: mdast.ThematicBreak, ctx: Context) {
 
 function buildBlockquote({ type, children }: mdast.Blockquote, ctx: Context) {
   // FIXME: do nothing for now
-  return <ContentText>{ text: convertNodes(children, ctx) };
+  return <ContentText>{ text: convertNodes(children, ctx), style: type };
 }
 
 function buildList(
@@ -346,17 +330,17 @@ function buildTableCell(
 
 function buildHtml({ type, value }: mdast.HTML, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx) };
+  return <ContentText>{ text: buildText(value, ctx), style: type };
 }
 
 function buildCode({ type, value, lang, meta }: mdast.Code, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx) };
+  return <ContentText>{ text: buildText(value, ctx), style: type };
 }
 
 function buildMath({ type, value }: mdast.Math, ctx: Context) {
   // FIXME: transform to text for now
-  return <ContentText>{ text: buildText(value, ctx) };
+  return <ContentText>{ text: buildText(value, ctx), style: type };
 }
 
 function buildInlineMath({ type, value }: mdast.InlineMath, ctx: Context) {


### PR DESCRIPTION
i added styles

now its possible add styles calling a function like this here:
` const processor = unified().use(markdown).use(pdf, {
      output: "blob",
      styles: {
        "head1": {
          "fontSize": 24,
          "color": "#025A6E"
        },
        "head2": {
          "fontSize": 22,
          "color": "#025A6E",
          "marginTop": 10,
        },
        "head3": {
          "fontSize": 20,
          "color": "#025A6E"
        },
        "head4": {
          "fontSize": 18,
          "color": "#025A6E"
        },
        "head5": {
          "fontSize": 16
        },
        "head6": {
          "fontSize": 14
        },
        "paragraph": {
          "fontSize": 20,
          "color": "red",
        },
        "document": {
          "color": "red",
        },
        "text": {
          "fontSize": 20,
          "color": "red",
        },
        "color": "red",
      }
    });`

![image](https://github.com/user-attachments/assets/50c60f37-e4bc-4af3-880a-b747530a0fbe)
