### PR TITLE
Update pdfmake version to 0.2.20; fixed vfs initialisation in browser…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "prepublishOnly": "rimraf lib && npm run build"
   },
   "dependencies": {
-    "@types/pdfmake": "^0.1.20",
-    "pdfmake": "^0.2.4",
+    "@types/pdfmake": "^0.2.11",
+    "pdfmake": "^0.2.20",
     "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import { mdastToPdf, PdfOptions, ImageDataMap } from "./transformer";
 
 import * as pdfMake from "pdfmake/build/pdfmake";
 import * as pdfFonts from "pdfmake/build/vfs_fonts";
-(pdfMake as any).vfs = pdfFonts.pdfMake.vfs;
+(pdfMake as any).addVirtualFileSystem(pdfFonts);
 
 export type { PdfOptions };
 


### PR DESCRIPTION
The error fixed is the following:
```
[ERROR] Cannot assign to import "vfs"
     node_modules/remark-pdf/lib/index.mjs:316:8:
       316 | pdfMake.vfs = pdfFonts.pdfMake.vfs;
           |         ~~~

   Imports are immutable in JavaScript. To modify the value of this import, you must export a setter function in the imported file (e.g. "setVfs") and then import and call that function here instead.
```