### PR TITLE
add preventOrphans boolean

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -71,7 +71,8 @@ export interface PdfOptions
    */
   imageResolver?: ImageResolver;
   info?: TDocumentInformation;
-  fonts?: TFontDictionary
+  fonts?: TFontDictionary;
+  preventOrphans?: boolean;
 }
 
 export function mdastToPdf(
@@ -89,6 +90,7 @@ export function mdastToPdf(
     permissions,
     version,
     watermark,
+    preventOrphans
   }: PdfOptions,
   images: ImageDataMap,
   build: (def: TDocumentDefinitions & { fonts?: TFontDictionary }) => Promise<any>
@@ -122,6 +124,10 @@ export function mdastToPdf(
     pageMargins,
     pageOrientation,
     pageSize,
+    pageBreakBefore: preventOrphans
+      ? (currentNode, restNodes) =>
+        currentNode.headlineLevel === 1 && restNodes.length === 0
+      : undefined,
     userPassword,
     ownerPassword,
     permissions,


### PR DESCRIPTION
Add a `preventOrphans` feature which adds a page break before a heading if that heading would be cut off from its content. Taken from [pdfmake documentation](https://pdfmake.github.io/docs/0.1/document-definition-object/page/#dynamically-control-page-breaks-for-instance-to-avoid-orphan-children).